### PR TITLE
refactor: Replace Tailwind CSS with standard CSS

### DIFF
--- a/my-app/package-lock.json
+++ b/my-app/package-lock.json
@@ -13,14 +13,11 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
-        "autoprefixer": "^10.4.21",
         "is-odd": "^3.0.1",
-        "postcss": "^8.5.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.1",
         "react-scripts": "5.0.1",
-        "tailwindcss": "^4.1.8",
         "web-vitals": "^2.1.4"
       }
     },
@@ -14784,11 +14781,6 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
-    },
-    "node_modules/tailwindcss": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.8.tgz",
-      "integrity": "sha512-kjeW8gjdxasbmFKpVGrGd5T4i40mV5J2Rasw48QARfYeQ8YS9x02ON9SFWax3Qf616rt4Cp3nVNIj6Hd1mP3og=="
     },
     "node_modules/tapable": {
       "version": "2.2.2",

--- a/my-app/package.json
+++ b/my-app/package.json
@@ -7,14 +7,11 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
-    "autoprefixer": "^10.4.21",
     "is-odd": "^3.0.1",
-    "postcss": "^8.5.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.1",
     "react-scripts": "5.0.1",
-    "tailwindcss": "^4.1.8",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/my-app/postcss.config.js
+++ b/my-app/postcss.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-}

--- a/my-app/src/App.css
+++ b/my-app/src/App.css
@@ -1,1 +1,55 @@
-/* Cleared App.css as per instructions */
+/* General App Layout */
+.app-container {
+  padding: 16px; /* Similar to p-4 */
+}
+
+/* Navigation Styles */
+.app-nav {
+  background-color: #e5e7eb; /* Similar to bg-gray-200 */
+  padding: 8px; /* Similar to p-2 */
+  margin-bottom: 16px; /* Similar to mb-4 */
+  border-radius: 4px; /* Similar to rounded */
+}
+
+.nav-list {
+  display: flex;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.nav-list li + li {
+  margin-left: 16px; /* Similar to space-x-4 */
+}
+
+.nav-link {
+  color: #3b82f6; /* Similar to text-blue-500 */
+  text-decoration: none;
+}
+
+.nav-link:hover {
+  color: #1d4ed8; /* Similar to hover:text-blue-700 */
+  text-decoration: underline;
+}
+
+/* Content Area Styles */
+.content-container {
+  padding: 16px; /* Similar to p-4 */
+  border: 1px solid #d1d5db; /* Similar to border */
+  border-radius: 4px; /* Similar to rounded */
+}
+
+/* Default body and code styles (can be kept from original CRA if desired, or added if missing) */
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+code {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+    monospace;
+}

--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -2,23 +2,23 @@ import React from 'react';
 import { Routes, Route, Link } from 'react-router-dom';
 import Home from './components/Home';
 import About from './components/About';
-import './App.css'; // Keep the import, even if the file is empty
+import './App.css'; // Ensure this is imported
 
 function App() {
   return (
-    <div className="p-4">
-      <nav className="bg-gray-200 p-2 mb-4 rounded">
-        <ul className="flex space-x-4">
+    <div className="app-container"> {/* Was p-4 */}
+      <nav className="app-nav"> {/* Was bg-gray-200 p-2 mb-4 rounded */}
+        <ul className="nav-list"> {/* Was flex space-x-4 */}
           <li>
-            <Link to="/" className="text-blue-500 hover:text-blue-700">Home</Link>
+            <Link to="/" className="nav-link">Home</Link> {/* Was text-blue-500 hover:text-blue-700 */}
           </li>
           <li>
-            <Link to="/about" className="text-blue-500 hover:text-blue-700">About</Link>
+            <Link to="/about" className="nav-link">About</Link> {/* Was text-blue-500 hover:text-blue-700 */}
           </li>
         </ul>
       </nav>
 
-      <div className="p-4 border rounded">
+      <div className="content-container"> {/* Was p-4 border rounded */}
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/about" element={<About />} />

--- a/my-app/src/components/About.css
+++ b/my-app/src/components/About.css
@@ -1,0 +1,11 @@
+.about-container {
+  padding: 1em;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.about-container h1 {
+  font-size: 2em;
+  font-weight: bold;
+  margin-bottom: 0.5em;
+}

--- a/my-app/src/components/About.js
+++ b/my-app/src/components/About.js
@@ -1,9 +1,10 @@
 import React from 'react';
+import './About.css'; // New import
 
 function About() {
   return (
-    <div>
-      <h1 className="text-2xl font-bold">About Page</h1>
+    <div className="about-container"> {/* Example class */}
+      <h1>About Page</h1>
       <p>This is the About Page.</p>
     </div>
   );

--- a/my-app/src/components/Home.css
+++ b/my-app/src/components/Home.css
@@ -1,0 +1,11 @@
+.home-container {
+  padding: 1em;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.home-container h1 {
+  font-size: 2em; /* Replaces text-2xl */
+  font-weight: bold; /* Replaces font-bold */
+  margin-bottom: 0.5em;
+}

--- a/my-app/src/components/Home.js
+++ b/my-app/src/components/Home.js
@@ -1,9 +1,10 @@
 import React from 'react';
+import './Home.css'; // New import
 
 function Home() {
   return (
-    <div>
-      <h1 className="text-2xl font-bold">Home Page</h1>
+    <div className="home-container"> {/* Example class */}
+      <h1>Home Page</h1>
       <p>Welcome to the Home Page!</p>
     </div>
   );

--- a/my-app/src/index.css
+++ b/my-app/src/index.css
@@ -1,7 +1,3 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',

--- a/my-app/tailwind.config.js
+++ b/my-app/tailwind.config.js
@@ -1,8 +1,0 @@
-/** @type {import('tailwindcss').Config} */
-module.exports = {
-  content: ["./src/**/*.{js,jsx,ts,tsx}", "./public/index.html"],
-  theme: {
-    extend: {},
-  },
-  plugins: [],
-}


### PR DESCRIPTION
Replaces Tailwind CSS with standard CSS classes and stylesheets throughout the application.

Changes include:
- Uninstalled Tailwind CSS, PostCSS, and Autoprefixer.
- Removed Tailwind configuration files.
- Updated `src/index.css` to remove Tailwind directives.
- Refactored `App.js`, `Home.js`, and `About.js` to use dedicated CSS files (`App.css`, `Home.css`, `About.css`) for styling instead of Tailwind utility classes.

Note: Tests in `src/App.test.js` are currently failing with a "Cannot find module 'react-router-dom'" error. This is suspected to be an environment-specific issue, as the module is correctly installed and utilized by the application.